### PR TITLE
fix: Resolve 403 Forbidden error in Node.js proxy

### DIFF
--- a/server/node/server.cjs
+++ b/server/node/server.cjs
@@ -178,6 +178,9 @@ async function hubProxyFunc(req, res) {
         delete headersToSend.connection;
         delete headersToSend['content-length'];
         
+        const hubOrigin = new URL(hubURL).origin;
+        headersToSend.origin = hubOrigin;
+        
         const response = await fetch(externalURL, {
             method: req.method,
             headers: headersToSend,


### PR DESCRIPTION
# PR Checklist
- [ ] Have you checked if it works normally in all models? *Ignore this if it doesn't use models.*
- [x] Have you checked if it works normally in all web, local, and node hosted versions? If it doesn't, have you blocked it in those versions?
- [ ] Have you added type definitions?

# Description
Addresses a 403 Forbidden error encountered when using the Node.js local server as a proxy for hub API requests.

The issue was caused by the proxy not forwarding the Origin header to the hub server. The hub server likely rejected requests without this expected header.

This fix explicitly adds the Origin header to the forwarded requests, setting its value to the origin of the hub URL. This ensures proper authorization and allows account-related operations to function correctly in the Node.js environment.