### PR TITLE
feat: add segmented control for Gemini 3.x thinking level

### DIFF
--- a/src/ts/model/providers/google.ts
+++ b/src/ts/model/providers/google.ts
@@ -9,7 +9,7 @@ export const GoogleModels: LLMModel[] = [
         provider: LLMProvider.GoogleCloud,
         format: LLMFormat.GoogleCloud,
         flags: [LLMFlags.hasImageInput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput, LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole, LLMFlags.geminiThinking],
-        parameters: ['thinking_tokens', 'temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
+        parameters: ['gemini_thinking_level', 'temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
         tokenizer: LLMTokenizer.GoogleCloud,
         recommended: true
     },
@@ -20,7 +20,7 @@ export const GoogleModels: LLMModel[] = [
         provider: LLMProvider.GoogleCloud,
         format: LLMFormat.GoogleCloud,
         flags: [LLMFlags.hasImageInput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput, LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole, LLMFlags.geminiThinking],
-        parameters: ['thinking_tokens', 'temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
+        parameters: ['gemini_thinking_level', 'temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
         tokenizer: LLMTokenizer.GoogleCloud,
         recommended: true
     },
@@ -30,7 +30,7 @@ export const GoogleModels: LLMModel[] = [
         provider: LLMProvider.GoogleCloud,
         format: LLMFormat.GoogleCloud,
         flags: [LLMFlags.hasImageInput, LLMFlags.poolSupported, LLMFlags.hasAudioInput, LLMFlags.hasVideoInput, LLMFlags.hasStreaming, LLMFlags.requiresAlternateRole, LLMFlags.geminiThinking],
-        parameters: ['thinking_tokens', 'temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
+        parameters: ['gemini_thinking_level', 'temperature', 'top_k', 'top_p', 'presence_penalty', 'frequency_penalty'],
         tokenizer: LLMTokenizer.GoogleCloud,
         recommended: true
     },

--- a/src/ts/process/request/google.ts
+++ b/src/ts/process/request/google.ts
@@ -303,7 +303,7 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
     let para:LLMParameter[] = ['temperature', 'top_p', 'top_k', 'presence_penalty', 'frequency_penalty']
 
     if(arg.modelInfo.flags.includes(LLMFlags.geminiThinking)){
-        para.push('thinking_tokens')
+        para.push('thinking_tokens', 'gemini_thinking_level')
     }
 
     para = para.filter((v) => {
@@ -319,7 +319,8 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
             'top_k': "topK",
             'presence_penalty': "presencePenalty",
             'frequency_penalty': "frequencyPenalty",
-            'thinking_tokens': "thinkingBudget"
+            'thinking_tokens': "thinkingBudget",
+            'gemini_thinking_level': "geminiThinkingLevel"
         }, arg.mode, {
             ignoreTopKIfZero: true
         }),
@@ -345,31 +346,22 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
 
     if(arg.modelInfo.flags.includes(LLMFlags.geminiThinking)){
         const internalId = arg.modelInfo.internalID
-        const thinkingBudget = body.generation_config.thinkingBudget
-
-        // Gemini 3 models use `thinking_level` (via thinkingConfig.thinkingLevel) instead of `thinking_budget`.
-        // Keep UI/param name 'thinking_tokens' but translate it here for compatibility.
-        if (internalId && /^gemini-3-/.test(internalId)) {
-            const budgetNum = typeof thinkingBudget === 'number' ? thinkingBudget : Number(thinkingBudget)
-
-            // Conservative mapping: keep levels coarse to avoid model-specific strict validation.
-            // - gemini-3-flash-preview: LOW/MEDIUM/HIGH
-            // - gemini-3-pro* (incl. image): LOW/HIGH
-            let thinkingLevel: 'LOW' | 'MEDIUM' | 'HIGH' = 'HIGH'
-            if (internalId === 'gemini-3-flash-preview') {
-                if (!Number.isFinite(budgetNum) || budgetNum >= 16384) thinkingLevel = 'HIGH'
-                else if (budgetNum >= 4096) thinkingLevel = 'MEDIUM'
-                else thinkingLevel = 'LOW'
-            } else {
-                if (!Number.isFinite(budgetNum) || budgetNum >= 8192) thinkingLevel = 'HIGH'
-                else thinkingLevel = 'LOW'
-            }
-
-            body.generation_config.thinkingConfig = {
-                "thinkingLevel": thinkingLevel,
+        
+        // Gemini 3 and 3.1 models use `thinkingLevel` via segment control UI
+        if (internalId && /^gemini-3(\.\d+)?-/.test(internalId)) {
+            const rawThinkingLevel = body.generation_config.geminiThinkingLevel
+            
+            let thinkingConfig: any = {
                 "includeThoughts": true,
             }
+            
+            if (rawThinkingLevel && rawThinkingLevel !== 'default') {
+                thinkingConfig.thinkingLevel = rawThinkingLevel.toUpperCase()
+            }
+            
+            body.generation_config.thinkingConfig = thinkingConfig
         } else {
+            const thinkingBudget = body.generation_config.thinkingBudget
             body.generation_config.thinkingConfig = {
                 "thinkingBudget": thinkingBudget,
                 "includeThoughts": true,
@@ -377,6 +369,7 @@ export async function requestGoogleCloudVertex(arg:RequestDataArgumentExtended):
         }
 
         delete body.generation_config.thinkingBudget
+        delete body.generation_config.geminiThinkingLevel
     }
 
     if(systemPrompt === ''){

--- a/src/ts/process/request/shared.ts
+++ b/src/ts/process/request/shared.ts
@@ -11,6 +11,7 @@ export type LLMParameter =
     | 'presence_penalty'
     | 'reasoning_effort'
     | 'thinking_tokens'
+    | 'gemini_thinking_level'
     | 'verbosity'
 
 export type ModelModeExtended = 'model' | 'submodel' | 'memory' | 'emotion' | 'otherAx' | 'translate'
@@ -121,6 +122,10 @@ export function applyParameters(
                     value = db.seperateParameters[ModelMode].thinking_tokens
                     break
                 }
+                case 'gemini_thinking_level': {
+                    value = db.seperateParameters[ModelMode].gemini_thinking_level ?? 'default'
+                    break
+                }
                 case 'frequency_penalty': {
                     value =
                         db.seperateParameters[ModelMode].frequency_penalty === -1000
@@ -207,6 +212,10 @@ export function applyParameters(
             }
             case 'thinking_tokens': {
                 value = db.thinkingTokens
+                break
+            }
+            case 'gemini_thinking_level': {
+                value = db.geminiThinkingLevel
                 break
             }
         }

--- a/src/ts/setting/botSettingsParamsData.ts
+++ b/src/ts/setting/botSettingsParamsData.ts
@@ -174,6 +174,22 @@ export const modelSpecificParameterItems: SettingItem[] = [
         keywords: ['adaptive', 'thinking', 'effort'],
     },
     {
+        id: 'params.geminiThinkingLevel',
+        type: 'segmented',
+        labelKey: 'geminiThinkingLevel',
+        bindKey: 'geminiThinkingLevel',
+        condition: (ctx) => ctx.modelInfo.parameters.includes('gemini_thinking_level'),
+        options: {
+            segmentOptions: [
+                { value: 'default', label: 'Off(Dynamic)' },
+                { value: 'low', label: 'Low' },
+                { value: 'medium', label: 'Medium' },
+                { value: 'high', label: 'High' },
+            ]
+        },
+        keywords: ['gemini', 'thinking', 'level', 'reasoning'],
+    },
+    {
         id: 'params.topK',
         type: 'slider',
         fallbackLabel: 'Top K',
@@ -277,6 +293,7 @@ export const allBasicParameterItems: SettingItem[] = [
     modelSpecificParameterItems.find(i => i.id === 'params.thinkingType')!,
     modelSpecificParameterItems.find(i => i.id === 'params.thinkingTokens')!,
     modelSpecificParameterItems.find(i => i.id === 'params.adaptiveThinkingEffort')!,
+    modelSpecificParameterItems.find(i => i.id === 'params.geminiThinkingLevel')!,
     ...samplingParameterItems, // temperature
     modelSpecificParameterItems.find(i => i.id === 'params.topK')!,
     modelSpecificParameterItems.find(i => i.id === 'params.minP')!,

--- a/src/ts/storage/database.svelte.ts
+++ b/src/ts/storage/database.svelte.ts
@@ -556,6 +556,7 @@ export function setDatabase(data:Database){
     data.useExperimentalGoogleTranslator ??= false
     data.thinkingType ??= 'budget'
     data.adaptiveThinkingEffort ??= 'high'
+    data.geminiThinkingLevel ??= 'default'
     if(data.antiClaudeOverload){ //migration
         data.antiClaudeOverload = false
         data.antiServerOverloads = true
@@ -1050,6 +1051,7 @@ export interface Database{
     thinkingTokens: number
     thinkingType: 'off' | 'budget' | 'adaptive'
     adaptiveThinkingEffort: 'low' | 'medium' | 'high' | 'max'
+    geminiThinkingLevel: 'default' | 'low' | 'medium' | 'high'
     antiServerOverloads: boolean
     hypaCustomSettings: {
         url: string,
@@ -1168,6 +1170,7 @@ interface SeparateParameters{
     thinking_tokens?:number
     thinking_type?: 'off' | 'budget' | 'adaptive'
     adaptive_thinking_effort?: 'low' | 'medium' | 'high' | 'max'
+    gemini_thinking_level?: 'default' | 'low' | 'medium' | 'high'
     outputImageModal?:boolean
     verbosity?:number
 }
@@ -1505,6 +1508,7 @@ export interface botPreset{
     thinkingTokens?:number
     thinkingType?: 'off' | 'budget' | 'adaptive'
     adaptiveThinkingEffort?: 'low' | 'medium' | 'high' | 'max'
+    geminiThinkingLevel?: 'default' | 'low' | 'medium' | 'high'
     outputImageModal?:boolean
     seperateModelsForAxModels?:boolean
     seperateModels?:{
@@ -1942,6 +1946,7 @@ export function saveCurrentPreset(){
         thinkingTokens: db.thinkingTokens ?? null,
         thinkingType: db.thinkingType ?? 'budget',
         adaptiveThinkingEffort: db.adaptiveThinkingEffort ?? 'high',
+        geminiThinkingLevel: db.geminiThinkingLevel ?? 'default',
         outputImageModal: db.outputImageModal ?? false,
         seperateModelsForAxModels: db.doNotChangeSeperateModels ? false : db.seperateModelsForAxModels ?? false,
         seperateModels: db.doNotChangeSeperateModels ? null : safeStructuredClone(db.seperateModels),
@@ -2071,6 +2076,7 @@ export function setPreset(db:Database, newPres: botPreset){
     db.thinkingTokens = newPres.thinkingTokens ?? null
     db.thinkingType = newPres.thinkingType ?? 'budget'
     db.adaptiveThinkingEffort = newPres.adaptiveThinkingEffort ?? 'high'
+    db.geminiThinkingLevel = newPres.geminiThinkingLevel ?? 'default'
     db.outputImageModal = newPres.outputImageModal ?? false
     if(!db.doNotChangeSeperateModels){
         db.seperateModelsForAxModels = newPres.seperateModelsForAxModels ?? false


### PR DESCRIPTION
## PR Checklist

- Required Checks
    - [x] Have you added type definitions?
    - [x] Have you tested your changes?
    - [x] Have you checked that it won't break any existing features?
- [x] If your PR uses models[^1], check the following:
    - [ ] Have you checked if it works normally in all models?
    - [x] Have you checked if it works normally in all web, local, and node-hosted versions? If it doesn't, have you blocked it in those versions?
- [x] If your PR is highly AI generated[^2], check the following:
    - [x] Have you understood what the code does?
    - [x] Have you cleaned up any unnecessary or redundant code?
    - [x] Is it not a huge change?

[^1]: Modifies the behavior of prompting, requesting, or handling responses from AI models.
[^2]: Over 80% of the code is AI generated.

## Summary

Replace the numeric `thinking_tokens` budget-to-level conversion for Gemini 3.0/3.1 models with a dedicated `gemini_thinking_level` segmented control. Users can now directly select **Off(Dynamic)**, **Low**, **Medium**, or **High** reasoning level.

## Related Issues

- Depends on #(adaptive-thinking-segmented-control PR) for SegmentedControl component fixes.

## Changes

- **`src/ts/model/providers/google.ts`**: Changed Gemini 3.0 and 3.1 model parameter definitions from `thinking_tokens` to `gemini_thinking_level`.
- **`src/ts/process/request/google.ts`**: Refactored thinkingConfig payload construction. Gemini 3.x models now read the level directly from the segmented control value instead of converting a numeric budget. Fixed regex from `/^gemini-3-/` to `/^gemini-3(\\.\\d+)?-/` to also match Gemini 3.1.
- **`src/ts/process/request/shared.ts`**: Added `gemini_thinking_level` to the `LLMParameter` type union and `applyParameters` function.
- **`src/ts/setting/botSettingsParamsData.ts`**: Added segmented control UI definition with Off(Dynamic)/Low/Medium/High options.
- **`src/ts/storage/database.svelte.ts`**: Added `geminiThinkingLevel` to `Database`, `botPreset`, and `SeparateParameters` interfaces with proper migration defaults.

## Impact

- **Gemini 3.0/3.1 users**: Now have a clearer, more intuitive UI for controlling reasoning level. No more guessing which token budget maps to which level.
- **Gemini 2.5 and earlier**: No impact. These models continue to use `thinking_tokens` (numeric budget) as before.
- **Off(Dynamic)**: When selected, `thinkingLevel` is omitted from the API payload, letting the model decide its own reasoning depth dynamically.

## Additional Notes

- This PR is based on `feature/adaptive-thinking-segmented-control` which provides the SegmentedControl component fixes. Once that PR is merged, this PR's base will automatically update to `main`.